### PR TITLE
remove memory type check

### DIFF
--- a/src/coll/coll_check.cpp
+++ b/src/coll/coll_check.cpp
@@ -64,9 +64,6 @@ void ccl_check_usm_pointers(const ccl_coll_param& param) {
     if ((usm_type == sycl::usm::alloc::device) && !(dev.is_gpu() || dev.is_accelerator()))
         is_valid_type = false;
 
-    if (usm_type == sycl::usm::alloc::unknown)
-        is_valid_type = false;
-
     LOG_DEBUG("coll: ",
               ccl_coll_type_to_str(param.ctype),
               ", usm pointer type: ",


### PR DESCRIPTION
In before code, I get a pointer from virtual memory, but sycl::get_pointer_type will return unknown if check this pointer.
In oneCCL, I want to remove this memory type check to avoid throwing runtime error directly.

```
#include <sycl/sycl.hpp>

using namespace sycl::ext::oneapi::experimental;

int main(){

    sycl::queue q(sycl::default_selector_v, sycl::property::queue::enable_profiling{});
    auto device = q.get_device();
    std::cout << "Running on device: " << device.get_info<sycl::info::device::name>() << std::endl;

    auto mini = granularity_mode::minimum;
    auto reco = granularity_mode::recommended;

    auto syclContext = sycl::context(q.get_device());
    auto syclDevice = sycl::device(q.get_device());

    size_t mini_mem_granularity = get_mem_granularity(syclDevice, syclContext, mini);
    size_t reco_mem_granularity = get_mem_granularity(syclDevice, syclContext, reco);

    std::cout << "Minimum memory granularity: " << mini_mem_granularity << " bytes" << std::endl;
    std::cout << "Recommended memory granularity: " << reco_mem_granularity << " bytes" << std::endl;

    uintptr_t test_malloc1 = reserve_virtual_mem(mini_mem_granularity, syclContext);

    auto p_type = sycl::get_pointer_type(reinterpret_cast<void*>(test_malloc1), syclContext);
    std::cout << "is_unknown?:" << (p_type == sycl::usm::alloc::unknown) << std::endl;

    return 0;
}
```

Output:
```
Running on device: Intel(R) Graphics [0xe211]
Minimum memory granularity: 65536 bytes
Recommended memory granularity: 65536 bytes
is_unknown?:1
```