### PR TITLE
[DOCS] Add specification pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ oneCCL is integrated into:
 * [Horovod\*](https://github.com/horovod/horovod) (distributed training framework). Refer to [Horovod with oneCCL](https://github.com/horovod/horovod/blob/master/docs/oneccl.rst) for details.
 * [PyTorch\*](https://github.com/pytorch/pytorch) (machine learning framework). Refer to [PyTorch bindings for oneCCL](https://github.com/intel/torch-ccl) for details.
 
-oneCCL is governed by the [UXL Foundation](http://www.uxlfoundation.org) and is an implementation of the [oneAPI specification](https://spec.oneapi.io).
+oneCCL is governed by the [UXL Foundation](http://www.uxlfoundation.org) and is an implementation of the [oneAPI specification](https://uxlfoundation.org/specifications/oneapi/technical-overview/). The oneCCL specification is published with this project's [documentation](https://uxlfoundation.github.io/oneCCL/spec/index.html).
 
 ## Table of Contents <!-- omit in toc -->
 

--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -1,6 +1,3 @@
-.. _`error handling`: https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/oneccl/source/spec/error_handling
-.. _`generic workflow`: https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/oneccl/source/spec/generic_workflow
-
 oneCCL API
 ===========
 
@@ -15,9 +12,9 @@ oneCCL API
 Generic workflow
 ****************
 
-Refer to |product_short| specification for more details about `generic workflow`_ with |product_short| API.
+Refer to |product_short| specification for more details about :doc:`generic workflow </spec/generic_workflow>` with |product_short| API.
 
 Error Handling
 **************
 
-Refer to |product_short| specification for more details about `error handling`_.
+Refer to |product_short| specification for more details about :doc:`error handling </spec/error_handling>`.

--- a/doc/rst/source/api/concepts.rst
+++ b/doc/rst/source/api/concepts.rst
@@ -1,9 +1,8 @@
-.. _`main concepts`: https://spec.oneapi.com/versions/latest/elements/oneCCL/source/spec/main_objects.html
-
 oneCCL Concepts
 ===============
 
-Refer to |product_short| specification for more details about |product_short| `main concepts`.
+Refer to |product_short| specification for more details about |product_short|
+:doc:`main concepts </spec/main_objects>`.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/rst/source/api/operations.rst
+++ b/doc/rst/source/api/operations.rst
@@ -1,9 +1,8 @@
-.. _`communication operations`: https://spec.oneapi.com/versions/latest/elements/oneCCL/source/spec/operations.html
-
 Communication Operations
 ========================
 
-Refer to |product_short| specification for more details about `communication operations`.
+Refer to |product_short| specification for more details about
+:doc:`communication operations </spec/collective_operations>`.
 
 .. toctree::
    :maxdepth: 2

--- a/doc/rst/source/conf.py
+++ b/doc/rst/source/conf.py
@@ -34,6 +34,7 @@ rst_prolog = """
 .. |base_tk| replace:: Intel\ |reg|\  oneAPI Base Toolkit 
 .. |c_api| replace:: C API
 .. |cpp_api| replace:: C++ API
+.. |ccl_full_name| replace:: oneAPI Collective Communications Library
 """
 
 # -- General configuration ---------------------------------------------------
@@ -102,6 +103,11 @@ breathe_default_project = "oneccl"
 #    "doxygenStripFromPath":  "..",
 #    "fullApiSubSectionTitle": 'Full API'
 #}
+
+# The specification and the developer reference document the same concepts
+# (Device, Communicator, Allreduce, ...), so section labels are qualified by
+# document to keep cross-references unambiguous.
+autosectionlabel_prefix_document = True
 
 # Tell sphinx what the primary language being documented is.
 primary_domain = 'cpp'

--- a/doc/rst/source/env-variables.rst
+++ b/doc/rst/source/env-variables.rst
@@ -2243,6 +2243,8 @@ Fusion
 The group of environment variables to control fusion of collective operations.
 
 
+.. _CCL_FUSION:
+
 CCL_FUSION
 **********
 

--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -43,6 +43,12 @@
    benchmark-guide/benchmark-point-to-point.rst
 
 .. toctree::
+   :maxdepth: 2
+   :caption: Specification
+
+   spec/index.rst
+
+.. toctree::
    :hidden: 
    :caption: Notices and Disclaimers
 

--- a/doc/rst/source/programming-model.rst
+++ b/doc/rst/source/programming-model.rst
@@ -1,4 +1,3 @@
-.. _`oneCCL specification`: https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneCCL/source/index.html
 Programming Model
 =================
 
@@ -8,13 +7,13 @@ The programming model for oneCCL describes how to:
 
 * Perform collective communication operations (for example, ALLREDUCE, BROADCAST, ALLGATHER).
 
-.. seealso:: See `oneCCL specification`_ that oneCCL is based on.
+.. seealso:: See the :ref:`oneCCL specification <oneCCL-section>` that oneCCL is based on.
 
 
 oneCCL supports a single rank/process per GPU device. The current implementation does not yet support a single process opening multiple devices.
 
 
-Review the oneCCL `generic workflow <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneCCL/source/spec/generic_workflow.html>`_ in the specification before getting started with the communication operations.
+Review the oneCCL :doc:`generic workflow </spec/generic_workflow>` in the specification before getting started with the communication operations.
 
 You can quickly get started with:
 

--- a/doc/rst/source/programming-model/device-communication.rst
+++ b/doc/rst/source/programming-model/device-communication.rst
@@ -1,5 +1,3 @@
-.. _`Communicator`: https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/oneccl/source/spec/main_objects#communicator
-
 ====================
 Device Communication
 ====================
@@ -139,5 +137,5 @@ If you encounter an error, make sure the oneCCL environment is configured correc
 Additional Resources
 ====================
 
-- `OneCCL Communicator <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneCCL/source/spec/main_objects.html#communicator>`_
-- `OneCCL ALLREDUCE communication pattern <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneCCL/source/spec/collective_operations.html#allreduce>`_
+- :ref:`oneCCL Communicator <Communicator>` in the specification
+- :ref:`oneCCL Allreduce communication pattern <Allreduce>` in the specification

--- a/doc/rst/source/programming-model/host-communication.rst
+++ b/doc/rst/source/programming-model/host-communication.rst
@@ -1,5 +1,3 @@
-.. _`Communicator`: https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/oneccl/source/spec/main_objects#communicator
-
 ==================
 Host Communication
 ==================
@@ -66,5 +64,5 @@ If you encounter an error, make sure the oneCCL environment is configured correc
 Additional Resources
 ====================
 
-- `OneCCL Communicator <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneCCL/source/spec/main_objects.html#communicator>`_
-- `OneCCL ALLREDUCE communication pattern <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneCCL/source/spec/collective_operations.html#allreduce>`_
+- :ref:`oneCCL Communicator <Communicator>` in the specification
+- :ref:`oneCCL Allreduce communication pattern <Allreduce>` in the specification

--- a/doc/rst/source/spec/collective_operations.rst
+++ b/doc/rst/source/spec/collective_operations.rst
@@ -1,0 +1,489 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+=====================
+Collective Operations
+=====================
+
+oneCCL specification defines the following collective communication operations:
+
+- :ref:`Allgather`
+- :ref:`Allgatherv`
+- :ref:`Allreduce`
+- :ref:`Alltoallv`
+- :ref:`Barrier`
+- :ref:`Broadcast`
+- :ref:`Reduce`
+- :ref:`ReduceScatter`
+
+These operations are collective, meaning that all participants (ranks) of oneCCL communicator should make a call.
+The order of collective operation calls should be the same across all ranks.
+
+``communicator`` shall provide the ability to perform communication operations either on host or device memory buffers depending on the ``device`` used to create the communicator. Additionally, communication operations shall accept an execution context (stream) and may accept a vector of events that the communication operation should depend on, that is, input dependencies. The output ``event`` object shall provide the ability to track the progress of the operation.
+
+.. note::
+    Support for handling of input events is optional
+
+``BufferType`` is used below to define the C++ type of elements in data buffers (``buf``, ``send_buf`` and  ``recv_buf``) of communication operations. At least the following types shall be supported: ``[u]int{8/16/32/64}_t``, ``float``, ``double``. The explicit ``datatype`` parameter shall be used to enable data types which cannot be inferred from the function arguments.
+
+.. note::
+    See also: :ref:`Custom Datatypes`
+
+The communication operation accepts a ``stream`` object. If a communicator is created from ``native_device_type``, then the stream shall translate to ``native_stream_type`` created from the corresponding device.
+
+The communication operation may accept attribute object. If that parameter is missed, then the default attribute object is used (default_<operation_name>_attr). The default attribute object shall be provided by the library.
+
+.. note::
+    See also: :doc:`operation_attributes`
+
+If the arguments provided to a communication operation call do not comply to the requirements of the operation, the behavior is undefined unless it is specified otherwise.
+
+
+.. _Allgather:
+
+Allgather
+*********
+
+Allgather is a collective communication operation that collects the ``send_count`` elements from all the ranks within the communicator and places the results into ``recv_buf``, in such a way that data from rank ``i`` can be found at offset rank ``i * count``. The resulting data in the output ``recv_buf`` buffer is the same for each rank. 
+
+
+Allgather is in place when ``sendbuff == recvbuff + rank * send_count``. 
+
+.. code:: cpp
+
+     template<class BufferType> 
+     event ccl::allgather(const BufferType* send_buf, 
+                          BufferType* recv_buf, 
+                          size_t send_count, 
+                          const communicator& comm, 
+                          const stream& stream, 
+                          const allgather_attr& attr = default_allgather_attr, 
+                          const vector_class<event>& deps = {}); 
+
+     event ccl::allgather(const void* send_buf, 
+                          void* recv_buf, 
+                          size_t send_count, 
+                          datatype dtype,  
+                          const communicator& comm, 
+                          const stream& stream, 
+                          const allgather_attr& attr = default_allgather_attr, 
+                          const vector_class<event>& deps = {}); 
+
+
+
+send_buf 
+    The buffer with send_count elements of BufferType that stores local data to be gathered 
+
+recv_buf [out] 
+    The buffer to store gathered result of BufferTuype, must be large enough to hold values from all ranks, i.e., size should be equal do BufferType * send_count 
+
+send_count 
+    The number of elements of type BufferType in send_buf 
+
+dtype 
+    The datatype of elements in send_buf and recv_buf must be skipped if BufferType can be inferred otherwise must be passed explicitly 
+
+comm 
+    The communicator that defines a group of ranks for the operation 
+
+stream 
+    The stream associated with the operation  
+
+attr 
+    Optional attributes to customize the operation 
+
+deps 
+    An optional vector of the events that the operation should depend on 
+
+return event 
+    An object to track the progress of the operation 
+
+.. _Allgatherv:
+
+Allgatherv
+**********
+
+Allgatherv is a collective communication operation that collects data from all
+the ranks within a communicator into a single buffer. Different ranks may
+contribute segments of different sizes. The resulting data in the output buffer
+must be the same for each rank.
+
+Allgatherv is in place when  ``send_buf == recv_buf + rank_offset``, where
+``rank_offset = sum (recv_counts[i])``, for all ``i < rank``.
+
+.. code:: cpp
+
+    template<class BufferType>
+    event ccl::allgatherv(const BufferType* send_buf,
+                          size_t send_count,
+                          BufferType* recv_buf,
+                          const vector_class<size_t>& recv_counts,
+                          const communicator& comm,
+                          const stream& stream,
+                          const allgatherv_attr& attr = default_allgatherv_attr,
+                          const vector_class<event>& deps = {});
+
+    event ccl::allgatherv(const void* send_buf,
+                          size_t send_count,
+                          void* recv_buf,
+                          const vector_class<size_t>& recv_counts,
+                          datatype dtype,
+                          const communicator& comm,
+                          const stream& stream,
+                          const allgatherv_attr& attr = default_allgatherv_attr,
+                          const vector_class<event>& deps = {});
+
+send_buf
+    the buffer with ``send_count`` elements of ``BufferType`` that stores local data to be gathered
+send_count
+    the number of elements of type ``BufferType`` in ``send_buf``
+recv_buf [out]
+    the buffer to store the gathered result, must be large enough to hold values from all ranks
+recv_counts
+    | an array with the number of elements of type ``BufferType`` to be received from each rank
+    | the array's size must be equal to the number of ranks
+    | the values in the array are expected to be the same for all ranks
+    | the value at the position of the caller's rank must be equal to ``send_count``
+dtype
+    | the datatype of elements in ``send_buf`` and ``recv_buf``
+    | must be skipped if ``BufferType`` can be inferred
+    | otherwise must be passed explicitly
+comm
+    the communicator that defines a group of ranks for the operation
+stream
+    the stream associated with the operation
+attr
+    optional attributes to customize the operation
+deps
+    an optional vector of the events that the operation should depend on
+return ``event``
+    an object to track the progress of the operation
+
+
+.. _Allreduce:
+
+Allreduce
+*********
+
+Allreduce is a collective communication operation that performs the global
+reduction operation on values from all ranks of communicator and distributes
+the result back to all ranks.
+
+Allreduce is in-place when ``send_buf == recv_buf``.
+
+.. code:: cpp
+
+    template <class BufferType>
+    event ccl::allreduce(const BufferType* send_buf,
+                         BufferType* recv_buf,
+                         size_t count,
+                         reduction rtype,
+                         const communicator& comm,
+                         const stream& stream,
+                         const allreduce_attr& attr = default_allreduce_attr,
+                         const vector_class<event>& deps = {});
+
+    event ccl::allreduce(const void* send_buf,
+                         void* recv_buf,
+                         size_t count,
+                         reduction rtype,
+                         datatype dtype,
+                         const communicator& comm,
+                         const stream& stream,
+                         const allreduce_attr& attr = default_allreduce_attr,
+                         const vector_class<event>& deps = {});
+
+send_buf
+    the buffer with ``count`` elements of ``BufferType`` that stores local data to be reduced
+recv_buf [out]
+    the buffer to store the reduced result, must have the same dimension as ``send_buf``
+count
+    the number of elements of type ``BufferType`` in ``send_buf`` and ``recv_buf``
+rtype
+    the type of the reduction operation to be applied
+dtype
+    | the datatype of elements in ``send_buf`` and ``recv_buf``
+    | must be skipped if ``BufferType`` can be inferred
+    | otherwise must be passed explicitly
+comm
+    the communicator that defines a group of ranks for the operation
+stream
+    the stream associated with the operation
+attr
+    optional attributes to customize the operation
+deps
+    an optional vector of the events that the operation should depend on
+return ``event``
+    an object to track the progress of the operation
+
+
+.. _Alltoallv:
+
+Alltoallv
+*********
+
+Alltoall is a collective communication operation in which each rank
+sends separate blocks of data to each rank. Block sizes may differ.
+The j-th block of send buffer sent from the i-th rank is received by the j-th rank
+and is placed in the i-th block of receive buffer.
+
+.. code:: cpp
+
+    template <class BufferType>
+    event ccl::alltoallv(const BufferType* send_buf,
+                         const vector_class<size_t>& send_counts,
+                         BufferType* recv_buf,
+                         const vector_class<size_t>& recv_counts,
+                         const communicator& comm,
+                         const stream& stream,
+                         const alltoallv_attr& attr = default_alltoallv_attr,
+                         const vector_class<event>& deps = {});
+
+    event ccl::alltoallv(const void* send_buf,
+                         const vector_class<size_t>& send_counts,
+                         void* recv_buf,
+                         const vector_class<size_t>& recv_counts,
+                         datatype dtype,
+                         const communicator& comm,
+                         const stream& stream,
+                         const alltoallv_attr& attr = default_alltoallv_attr,
+                         const vector_class<event>& deps = {});
+
+send_buf
+    the buffer with elements of ``BufferType`` that stores local blocks to be sent to each rank
+send_counts
+    | an array with number of elements of type ``BufferType`` in the blocks sent for each rank
+    | the array's size must be equal to the number of ranks
+    | the values at the position of the caller's rank in ``send_counts`` and ``recv_counts`` must be equal
+recv_buf [out]
+    the buffer to store the received result, must be large enough to hold blocks from all ranks
+recv_counts
+    | an array with number of elements of type ``BufferType`` in the blocks received from each rank
+    | the array's size must be equal to the number of ranks
+    | the values at the position of the caller's rank in ``send_counts`` and ``recv_counts`` must be equal
+dtype
+    | the datatype of elements in ``send_buf`` and ``recv_buf``
+    | must be skipped if ``BufferType`` can be inferred
+    | otherwise must be passed explicitly
+comm
+    the communicator that defines a group of ranks for the operation
+stream
+    the stream associated with the operation
+attr
+    optional attributes to customize the operation
+deps
+    an optional vector of the events that the operation should depend on
+return ``event``
+    an object to track the progress of the operation
+
+
+.. _Barrier:
+
+Barrier
+*******
+
+Barrier synchronization is performed across all ranks of the communicator
+and it is completed only after all the ranks in the communicator have called it.
+
+.. code:: cpp
+
+    event ccl::barrier(const communicator& comm,
+                       const stream& stream,
+                       const barrier_attr& attr = default_barrier_attr,
+                       const vector_class<event>& deps = {});
+
+comm
+    the communicator that defines a group of ranks for the operation
+stream
+    the stream associated with the operation
+attr
+    optional attributes to customize the operation
+deps
+    an optional vector of the events that the operation should depend on
+return ``event``
+    an object to track the progress of the operation
+
+
+.. _Broadcast:
+
+Broadcast
+*********
+
+Broadcast is a collective communication operation that broadcasts data from one rank of communicator (denoted as root) to all other ranks.
+
+Broadcast is in-place if send_buf == recv_buf 
+
+.. code:: cpp
+
+    template <class BufferType> 
+    event ccl::broadcast(BufferType*send_buf, 
+                         BufferType*recv_buf, 
+                         size_t count, 
+                         int root, 
+                         const communicator& comm, 
+                         const stream& stream, 
+                         const broadcast_attr& attr = default_broadcast_attr, 
+                         const vector_class<event>& deps = {}); 
+ 
+     event ccl::broadcast(void* send_buf, 
+                          void* recv_buf 
+                          size_t count, 
+                          datatype dtype, 
+                          int root, 
+                          const communicator& comm, 
+                          const stream& stream, 
+                          const broadcast_attr& attr = default_broadcast_attr, 
+                          const vector_class<event>& deps = {}); 
+ 
+
+send_buf [in,out]
+    The buffer with ``count`` elements of ``BufferType`` serves as ``send_buf`` for root and as ``recv_buf`` for other ranks
+count
+    The number of elements of type ``BufferType`` in ``buf``
+root
+    The rank that broadcasts ``buf``
+dtype
+     The datatype of elements in ``buf``
+     | must be skipped if ``BufferType`` can be inferred
+     | otherwise must be passed explicitly
+comm
+    The communicator that defines a group of ranks for the operation
+stream
+    The stream associated with the operation
+attr
+    Optional attributes to customize the operation
+deps
+    An optional vector of the events that the operation should depend on
+return ``event``
+    An object to track the progress of the operation
+
+
+.. _Reduce:
+
+Reduce
+******
+
+Reduce is a collective communication operation that performs the global
+reduction operation on values from all ranks of the communicator and returns
+the result to the root rank.
+
+Reduce is in-place when ``send_buf == recv_buf``.
+
+.. code:: cpp
+
+    template <class BufferType>
+    event ccl::reduce(const BufferType* send_buf,
+                      BufferType* recv_buf,
+                      size_t count,
+                      reduction rtype,
+                      int root,
+                      const communicator& comm,
+                      const stream& stream,
+                      const reduce_attr& attr = default_reduce_attr,
+                      const vector_class<event>& deps = {});
+
+    event ccl::reduce(const void* send_buf,
+                      void* recv_buf,
+                      size_t count,
+                      datatype dtype,
+                      reduction rtype,
+                      int root,
+                      const communicator& comm,
+                      const stream& stream,
+                      const reduce_attr& attr = default_reduce_attr,
+                      const vector_class<event>& deps = {});
+
+send_buf
+    the buffer with ``count`` elements of ``BufferType`` that stores local data to be reduced
+recv_buf [out]
+    | the buffer to store the reduced result, must have the same dimension as ``send_buf``.
+    | Used by the ``root`` rank only, ignored by other ranks.
+count
+    the number of elements of type ``BufferType`` in ``send_buf`` and ``recv_buf``
+rtype
+    the type of the reduction operation to be applied
+root
+    the rank that gets the result of the reduction
+dtype
+    | the datatype of elements in ``send_buf`` and ``recv_buf``
+    | must be skipped if ``BufferType`` can be inferred
+    | otherwise must be passed explicitly
+comm
+    the communicator that defines a group of ranks for the operation
+stream
+    the stream associated with the operation
+attr
+    optional attributes to customize the operation
+deps
+    an optional vector of the events that the operation should depend on
+return ``event``
+    an object to track the progress of the operation
+
+
+.. _ReduceScatter:
+
+ReduceScatter
+**************
+
+Reduce-scatter is a collective communication operation that performs the global
+reduction operation on values from all ranks of the communicator and scatters
+the result in blocks back to all ranks.
+
+ReduceScatter is in-place when ``recv_buf == send_buf + rank * recv_count``
+
+.. code:: cpp
+
+    template <class BufferType>
+    event ccl::reduce_scatter(const BufferType* send_buf,
+                              BufferType* recv_buf,
+                              size_t recv_count,
+                              reduction rtype,
+                              const communicator& comm,
+                              const stream& stream,
+                              const reduce_scatter_attr& attr = default_reduce_scatter_attr,
+                              const vector_class<event>& deps = {});
+
+    event ccl::reduce_scatter(const void* send_buf,
+                              void* recv_buf,
+                              size_t recv_count,
+                              datatype dtype,
+                              reduction rtype,
+                              const communicator& comm,
+                              const stream& stream,
+                              const reduce_scatter_attr& attr = default_reduce_scatter_attr,
+                              const vector_class<event>& deps = {});
+
+send_buf
+    the buffer with ``comm_size`` * ``count`` elements of ``BufferType`` that stores local data to be reduced
+recv_buf [out]
+    the buffer to store the result block containing ``recv_count`` elements of type ``BufferType``
+recv_count
+    the number of elements of type ``BufferType`` in the received block
+rtype
+    the type of the reduction operation to be applied
+dtype
+    | the datatype of elements in ``send_buf`` and ``recv_buf``
+    | must be skipped if ``BufferType`` can be inferred
+    | otherwise must be passed explicitly
+comm
+    the communicator that defines a group of ranks for the operation
+stream
+    the stream associated with the operation
+attr
+    optional attributes to customize the operation
+deps
+    an optional vector of the events that the operation should depend on
+return ``event``
+    an object to track the progress of the operation
+
+.. note::
+    See also:
+
+    - :ref:`Communicator`
+    - :ref:`Stream`
+    - :ref:`Event`
+    - :doc:`operation_progress`
+
+Point-to-point operations (``send`` and ``recv``) are specified separately from the collectives.
+See :doc:`Point-To-Point Operations </api/operations/point-to-point>` in the Developer Reference.

--- a/doc/rst/source/spec/datatypes.rst
+++ b/doc/rst/source/spec/datatypes.rst
@@ -1,0 +1,127 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+.. _`16-bit/half-precision floating point`: https://en.wikipedia.org/wiki/Half-precision_floating-point_format
+.. _`non-standard 16-bit floating point with 7-bit mantissa`: https://en.wikipedia.org/wiki/Bfloat16_floating-point_format
+
+=========
+Datatypes
+=========
+
+oneCCL specification defines the following datatypes that may be used for communication operations:
+
+.. code:: cpp
+
+    enum class datatype : int
+    {
+        int8            = /* unspecified */,
+        uint8           = /* unspecified */,
+        int16           = /* unspecified */,
+        uint16          = /* unspecified */,
+        int32           = /* unspecified */,
+        uint32          = /* unspecified */,
+        int64           = /* unspecified */,
+        uint64          = /* unspecified */,
+
+        float16         = /* unspecified */,
+        float32         = /* unspecified */,
+        float64         = /* unspecified */,
+        bfloat16        = /* unspecified */,
+
+        last_predefined = /* unspecified, equal to the largest of all the values above */
+    };
+
+datatype::int8
+    8 bits signed integer
+datatype::uint8
+    8 bits unsigned integer
+datatype::int16
+    16 bits signed integer
+datatype::uint16
+    16 bits unsigned integer
+datatype::int32
+    32 bits signed integer
+datatype::uint32
+    32 bits unsigned integer
+datatype::int64
+    64 bits signed integer
+datatype::uint64
+    64 bits unsigned integer
+datatype::float16
+    `16-bit/half-precision floating point`_
+datatype::float32
+    32-bit/single-precision floating point
+datatype::float64
+    64-bit/double-precision floating point
+datatype::bfloat16
+    `non-standard 16-bit floating point with 7-bit mantissa`_
+
+
+.. note::
+    Support for ``datatype::float16`` is optional
+
+
+.. _Custom Datatypes:
+
+Custom Datatypes
+****************
+
+oneCCL specification defines the way to register and deregister a custom datatype
+using the ``datatype_attr`` attribute object.
+
+
+The list of identifiers that may be used to fill an attribute object:
+
+.. code:: cpp
+
+    enum class datatype_attr_id {
+        size = /* unspecified */
+    };
+
+datatype_attr_id::size
+    the size of the datatype in bytes
+
+
+Creating a datatype attribute object, which may used to register custom datatype:
+
+.. code:: cpp
+
+    datatype_attr ccl::create_datatype_attr();
+
+return ``datatype_attr``
+    an object containing attributes for the custom datatype
+
+
+Registering a custom datatype to be used in communication operations:
+
+.. code:: cpp
+
+    datatype ccl::register_datatype(const datatype_attr& attr);
+
+attr
+    the datatype's attributes
+return ``datatype``
+    the handle for the custom datatype
+
+
+Deregistering a custom datatype:
+
+.. code:: cpp
+
+    void ccl::deregister_datatype(datatype dtype);
+
+dtype
+    the handle for the custom datatype
+
+
+Retrieving a datatype size in bytes:
+
+.. code:: cpp
+
+    size_t ccl::get_datatype_size(datatype dtype);
+
+dtype
+    the datatype's handle
+return ``size_t``
+    datatype size in bytes

--- a/doc/rst/source/spec/error_handling.rst
+++ b/doc/rst/source/spec/error_handling.rst
@@ -1,0 +1,43 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+==============
+Error handling
+==============
+
+oneCCL error handling relies on the mechanism of C++ exceptions. If an error
+occurs, it shall be propagated at the point of a function call where it is
+caught using standard C++ error handling mechanism.
+
+Exception classification
+************************
+
+Exception classification in oneCCL is aligned with C++ Standard Library classification. oneCCL introduces class that defines the base class in the hierarchy of oneCCL exception classes. All oneCCL routines throw exceptions inherited from this base class.
+
+In the hierarchy of oneCCL exceptions, ``ccl::exception`` is the base class inherited from ``std::exception`` class. All other oneCCL exception classes are derived from this base class.
+
+This specification does not require implementations to perform error-checking. However, if an implementation does provide error-checking, it shall use the following exception classes. Additional implementation-specific exception classes can be used for exceptional conditions not fitting any of these classes.
+
+Common exceptions
+*****************
+
+.. csv-table::
+    :header: "Exception class", "Description"
+    :widths: 40, 60
+
+    ".. _oneccl_exception:
+
+    ``ccl::exception``", "Reports general unspecified error"
+    ".. _oneccl_exception_invalid_argument:
+
+    ``ccl::invalid_argument``", "Reports an error when arguments to the operation were rejected"
+    ".. _oneccl_exception_host_bad_alloc:
+
+    ``ccl::host_bad_alloc``", "Reports an error that occurred during memory allocation on the host"
+    ".. _oneccl_exception_unimplemented:
+
+    ``ccl::unimplemented``", "Reports an error when the requested operation is not implemented"
+    ".. _oneccl_exception_unsupported:
+
+    ``ccl::unsupported``", "Reports an error when the requested operation is not supported"

--- a/doc/rst/source/spec/generic_workflow.rst
+++ b/doc/rst/source/spec/generic_workflow.rst
@@ -1,0 +1,97 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+================
+Generic Workflow
+================
+
+Below is a generic workflow with oneCCL API
+
+1. Create a main built-in key-value store. Its address should be distributed
+using an out-of-band communication mechanism and be used to create key-value stores on other processes:
+
+.. code:: cpp
+
+    using namespace std;
+
+    /* for example use MPI as an out-of-band communication mechanism */
+
+    int mpi_rank, mpi_size;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
+
+    ccl::shared_ptr_class<ccl::kvs> kvs;
+    ccl::kvs::address_type kvs_addr;
+
+    if (mpi_rank == 0) {
+        kvs = ccl::create_main_kvs();
+        kvs_addr = kvs->get_address();
+        MPI_Bcast((void*)kvs_addr.data(), ccl::kvs::address_max_size, MPI_BYTE, 0, MPI_COMM_WORLD);
+    }
+    else {
+        MPI_Bcast((void*)kvs_addr.data(), ccl::kvs::address_max_size, MPI_BYTE, 0, MPI_COMM_WORLD);
+        kvs = ccl::create_kvs(kvs_addr);
+    }
+
+2. Create communicator(s):
+
+.. code:: cpp
+
+    /* host communications */
+    auto comm = ccl::create_communicator(mpi_size, mpi_rank, kvs);
+
+.. code:: cpp
+
+    /* SYCL devices communications, for example with multiple devices per process */
+
+    /* sycl_context -> sycl::context */
+    /* sycl_devices -> vector<sycl::device> */
+    /* sycl_queues  -> vector<sycl::queue> */
+
+    /* create ccl::context object from sycl::context object */
+    auto ccl_context = ccl::create_context(sycl_context);
+
+    /* create ccl::device objects from sycl::device objects */
+    vector<ccl::device> ccl_devices;
+    for (size_t idx = 0; idx < sycl_devices.size(); idx++) {
+        ccl_devices.push_back(ccl::create_device(sycl_devices[idx]));
+    }
+
+    map<int, ccl::device> r2d_map;
+    for (auto& dev : ccl_devices) {
+        int rank = /* generate a globally unique rank for a specific device */
+        r2d_map[rank] = dev;
+    }
+
+    /* create ccl::stream objects from sycl::queue objects */
+    vector<ccl::stream> ccl_streams;
+    for (size_t idx = 0; idx < sycl_queues.size(); idx++) {
+        ccl_streams.push_back(ccl::create_stream(sycl_queues[idx]));
+    }
+
+    auto comms = ccl::create_communicators(mpi_size * r2d_map.size(),
+                                           r2d_map,
+                                           ccl_context,
+                                           kvs);
+
+3. Execute a communication operation of choice on the communicator(s):
+
+.. code:: cpp
+
+    /* host communications */
+    allreduce(..., comm).wait();
+
+.. code:: cpp
+
+    /* SYCL devices communications */
+    vector<ccl::event> events;
+    for (auto& comm : comms) {
+        events.push_back(allreduce(..., comm, ccl_streams[comm.rank()]));
+    }
+
+    for (auto& e : events) {
+        e.wait();
+    }

--- a/doc/rst/source/spec/group_calls.rst
+++ b/doc/rst/source/spec/group_calls.rst
@@ -1,0 +1,38 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+============
+Group Calls
+============
+
+oneCCL specification defines the following group calls: 
+
+* group_start() 
+* group_end() 
+
+
+Group calls serve to merge multiple calls into a single group operation. These operations are initiated and finalized using primary functions: group_start() and group_end(). 
+
+Group_start 
+***********
+
+.. code:: cpp
+
+    void CCL_API group_start();
+
+group_start() starts a group call. group_start() can be used to initiate a group call operation to indicate that successive operations should not get blocked due to CPU synchronization.  
+
+Group_end 
+*********
+
+.. code:: cpp
+
+    void CCL_API group_end();
+
+group_end() ends a group call. The group_end() call returns when all the operations between group_start() and group_end() have been enqueued for execution, but not necessarily completed. 
+
+
+.. note::
+    Currently group calls are supported for point-to-point and collective operations.  
+

--- a/doc/rst/source/spec/index.rst
+++ b/doc/rst/source/spec/index.rst
@@ -1,0 +1,47 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+.. _oneCCL-section:
+
+======================
+oneCCL Specification
+======================
+
+This section is the oneCCL specification: the requirements an implementation of |product_short|
+must meet. It states what each object and communication operation *shall* do, independently of how
+this library implements it.
+
+It is the companion to the :doc:`Developer Reference </api>`, which documents the API this
+implementation actually provides, generated from the headers. Read the specification for the
+contract; read the Developer Reference for the exact signatures, overloads, and the behavior
+specific to this implementation.
+
+oneCCL is one element of the oneAPI specification, which the UXL Foundation maintains
+dynamically: the shared programming model is described in the `oneAPI technical overview
+<https://uxlfoundation.org/specifications/oneapi/technical-overview/>`_, while each
+`specification element <https://uxlfoundation.org/specifications/oneapi/specification-elements/>`_
+is defined in its own project documentation. These pages are that definition for oneCCL.
+
+Namespaces
+==========
+
+The ``oneapi::ccl`` namespace shall contain public identifiers defined by the library.
+
+The alternative ``ccl`` namespace shall be considered an alias for the ``oneapi::ccl`` namespace.
+
+Contents
+========
+
+.. toctree::
+   :maxdepth: 1
+
+   generic_workflow.rst
+   main_objects.rst
+   datatypes.rst
+   reductions.rst
+   collective_operations.rst
+   operation_attributes.rst
+   operation_progress.rst
+   group_calls.rst
+   error_handling.rst

--- a/doc/rst/source/spec/main_objects.rst
+++ b/doc/rst/source/spec/main_objects.rst
@@ -1,0 +1,407 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+============
+Main Objects
+============
+
+oneCCL specification defines the following list of concepts:
+
+- `Device`_
+- `Context`_
+- `Key-Value Store`_
+- `Communicator`_
+- `Stream`_
+- `Event`_
+
+Communication operation behavior may additionally be controlled through
+:doc:`operation attributes <operation_attributes>`.
+
+
+.. _Device:
+
+Device
+******
+
+.. note::
+    Here and below, a native device/context/stream/event are defined in the scope of SYCL device runtime
+
+.. code:: cpp
+
+    using native_device_type = sycl::device;
+    using native_context_type = sycl::context;
+    using native_stream_type = sycl::queue;
+    using native_event_type = sycl::event;
+
+oneCCL specification defines ``device`` as an abstraction of a computational device: a CPU, a specific GPU card in the system, or any other device participating in a communication operation. ``device`` corresponds to the communicator's rank (addressable entity in a communication operation).
+
+oneCCL specification defines the way to create an instance of the ``device`` class with a native object (``native_device_type``) and without a native object (corresponds to the host).
+
+
+Creating a new device object:
+
+.. code:: cpp
+
+    device ccl::create_device(native_device_type& native_device);
+
+    device ccl::create_device();
+
+native_device
+    the existing native device object
+return ``device``
+    a device object
+
+``device`` class shall provide ability to retrieve a native object.
+
+Retrieving a native device object:
+
+.. code:: cpp
+
+    native_device_type device::get_native();
+
+return ``native_device_type``
+    | a native device object
+    | shall throw exception if a ``device`` object does not wrap the native object
+
+
+.. _Context:
+
+Context
+*******
+
+oneCCL specification defines ``context`` as an abstraction of a computational devices context that is responsible for managing resources and for executing of communication operations on one or more devices specified in the context.
+
+oneCCL specification defines the way to create an instance of the ``context`` class with a native object (``native_context_type``) and without a native object.
+
+
+Creating a new context object:
+
+.. code:: cpp
+
+    context ccl::create_context(native_context_type& native_context);
+
+    context ccl::create_context();
+
+native_context
+    the existing native context object
+return ``context``
+    a context object
+
+
+``context`` class shall provide ability to retrieve a native object.
+
+Retrieving a native context object:
+
+.. code:: cpp
+
+    native_context_type context::get_native();
+
+return ``native_context_type``
+    | a native context object
+    | shall throw exception if a ``context`` object does not wrap the native object
+
+
+Key-Value Store
+***************
+
+``kvs_interface`` defines the key-value store (KVS) interface to be used to establish connection between ranks during the creation of oneCCL communicator. The interface shall include blocking ``get`` and ``set`` methods.
+
+
+Getting a record from the key-value store:
+
+.. code:: cpp
+
+    virtual vector_class<char> kvs_interface::get(
+        const string_class& key) = 0;
+
+key
+    the key of value to be retrieved
+return ``vector_class<char>``
+    the value associated with the given key
+
+.. note::
+    ``get`` operation with a non-existing key shall return empty result
+
+
+Saving a record in the key-value store:
+
+.. code:: cpp
+
+    void kvs_interface::set(
+        const string_class& key,
+        const vector_class<char>& data) = 0;
+
+key
+    the key at which the value should be stored
+data
+    the value that should be associated with the given key
+
+.. note::
+    ``set`` operation with empty ``data`` shall remove a record from the key-value store
+
+
+oneCCL specification defines ``kvs`` class as a built-in KVS provided by oneCCL.
+
+.. code:: cpp
+
+    class kvs : public kvs_interface {
+    
+    public:
+
+    static constexpr size_t address_max_size = 256;
+    using address_type = array_class<char, address_max_size>;
+
+    ~kvs() override;
+
+    address_type get_address() const;
+
+    vector_class<char> get(
+        const string_class& key) override;
+
+    void set(
+        const string_class& key,
+        const vector_class<char>& data) override;
+
+    }
+
+
+Retrieving an address of built-in key-value store:
+
+.. code:: cpp
+
+    kvs::address_type kvs::get_address() const;
+
+return ``kvs::address_type``
+    | the address of the key-value store
+    | should be retrieved from the main built-in KVS and distributed to other processes for the built-in KVS creation
+
+
+Creating a main built-in key-value store. Its address should be distributed using an out-of-band communication mechanism
+and be used to create key-value stores on other ranks:
+
+.. code:: cpp
+
+    shared_ptr_class<kvs> ccl::create_main_kvs();
+
+return ``shared_ptr_class<kvs>``
+    the main key-value store object
+
+
+Creating a new key-value store from main kvs address:
+
+.. code:: cpp
+
+    shared_ptr_class<kvs> ccl::create_kvs(const kvs::address_type& addr);
+
+addr
+    the address of the main kvs
+return ``shared_ptr_class<kvs>``
+    key-value store object
+
+
+.. _Communicator:
+
+Communicator
+************
+
+oneCCL specification defines ``communicator`` class that describes a group of communicating ranks, where a rank is an addressable entity in a communication operation and corresponds to single oneCCL device.
+
+``communicator`` defines communication operations on memory buffers between homogeneous oneCCL devices, that is, all oneCCL devices either wrap native device objects of the same type (for example CPUs only or GPUs only) or do not wrap native objects.
+
+Each process may correspond to multiple ranks.
+
+.. note::
+    Support for multiple ranks per process is optional
+
+Creating a new communicator(s) with user-supplied communicator size, rank-to-device mapping/rank, context and kvs:
+
+.. note::
+  If ``device`` and ``context`` objects are omitted, then they are created with ``ccl::create_device()`` and ``ccl::create_context()`` functions without native objects
+
+.. code:: cpp
+
+    vector_class<communicator> ccl::create_communicators(
+        int size,
+        const map_class<int, device>& rank_device_map,
+        const context& context,
+        shared_ptr_class<kvs_interface> kvs);
+
+    communicator ccl::create_communicator(
+        int size,
+        int rank,
+        shared_ptr_class<kvs_interface> kvs);
+
+size
+    user-supplied total number of ranks
+rank_device_map
+    user-supplied mapping of local ranks on devices
+rank
+    user-supplied local rank
+context
+    device context
+kvs
+    key-value store for ranks wire-up
+return ``vector_class<communicator>`` / ``communicator``
+    a vector of communicator objects  / a communicator object
+
+
+``communicator`` shall provide methods to retrieve the rank, the device, and the context that correspond to the communicator object as well as the total number of ranks in the communicator.
+
+
+Retrieving the rank in a communicator:
+
+.. code:: cpp
+
+    int communicator::rank() const;
+
+return ``int``
+    the rank that corresponds to the communicator object
+
+
+Retrieving the total number of ranks in a communicator:
+
+.. code:: cpp
+
+    int communicator::size() const;
+
+return ``int``
+    the total number of the ranks
+
+
+Retrieving an underlying device, which was used as communicator construction argument:
+
+.. code:: cpp
+
+    device communicator::get_device() const;
+
+return ``device``
+    the device that corresponds to the communicator object
+
+
+Retrieving an underlying context, which was used as communicator construction argument:
+
+.. code:: cpp
+
+    context communicator::get_context() const;
+
+return ``context``
+    the context that corresponds to the communicator object
+
+.. note::
+    See also: :doc:`collective_operations`
+
+
+
+.. _Split_communicator:
+
+Split-Communicator
+******************
+
+The communicator provides methods to create one or more new communicators from an existing communicator. The new sub-communicators are created based on user-supplied color and key. Each newly formed sub-communicator includes only the ranks that provided the same color. Within each sub-communicator, ranks are reordered by the ascending key. This call is collective over all ranks in the communicator. 
+
+.. code:: cpp
+
+    communicator split_communicator(const communicator& comm, int color, int key); 
+
+``comm``
+   An existing communicator handle.
+
+``color``
+    A value that defines which ranks will belong to the new sub-communicator. Ranks providing the same color are part of the same sub-communicator.  
+
+``key``
+    Used to order the ranks within each sub-communicator. Ranks in the resulting communicator are sorted by the ascending key. 
+
+ 
+
+Return Value 
+
+``communicator``
+    The handle to the new sub-communicator  
+
+ 
+
+
+
+.. _Stream:
+
+Stream
+******
+
+oneCCL specification defines ``stream`` as an abstraction that encapsulates execution context for ``communicator`` communication operations.
+
+Stream shall be passed to ``communicator`` communication operation.
+
+oneCCL specification defines the way to create an instance of the ``stream`` class with a native object (``native_stream_type``) and without a native object.
+
+
+Creating a new stream object:
+
+.. code:: cpp
+
+    stream ccl::create_stream(native_stream_type& native_stream);
+
+    stream ccl::create_stream();
+
+native_stream
+    the existing native stream object
+return ``stream``
+    a stream object
+
+
+``stream`` class shall provide ability to retrieve a native object.
+
+Retrieving a native stream object:
+
+.. code:: cpp
+
+    native_stream_type stream::get_native();
+
+return ``native_stream_type``
+    | a native stream object
+    | shall throw exception if a ``stream`` object does not wrap the native object
+
+
+.. _Event:
+
+Event
+*****
+
+oneCCL specification defines ``event`` as an abstraction that encapsulates synchronization context for ``communicator`` communication operations.
+
+Each communication operation of oneCCL shall return an event object for tracking the operation's progress. A vector of events may be passed to the ``communicator`` communication operation to designate input dependencies for the operation.
+
+.. note::
+    Support for handling of input events is optional
+
+oneCCL specification defines the way to create an instance of the ``event`` class with a native object (``native_event_type``).
+
+
+Creating a new event object:
+
+.. code:: cpp
+
+    event ccl::create_event(native_event_type& native_event);
+
+native_event
+    the existing native event object
+return ``event``
+    an event object
+
+
+``event`` class shall provide ability to retrieve a native object.
+
+Retrieving a native event object:
+
+.. code:: cpp
+
+    native_event_type event::get_native();
+
+return ``native_event_type``
+    | a native event object
+    | shall throw exception if an ``event`` object does not wrap the native object
+
+
+.. note::
+    See also: :doc:`operation_progress`

--- a/doc/rst/source/spec/operation_attributes.rst
+++ b/doc/rst/source/spec/operation_attributes.rst
@@ -1,0 +1,95 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+====================
+Operation Attributes
+====================
+
+oneCCL specification defines communication operation attributes that serve as modifiers of an operation's behavior. Optionally, they may be passed to the corresponding communication operations.
+
+oneCCL specification defines the following operation attribute classes:
+
+- ``allgatherv_attr``
+- ``allreduce_attr``
+- ``alltoallv_attr``
+- ``barrier_attr``
+- ``broadcast_attr``
+- ``reduce_attr``
+- ``reduce_scatter_attr``
+
+oneCCL specification defines attribute identifiers that may be used to fill operation attribute objects.
+
+The list of common attribute identifiers that may be used for any communication operation:
+
+.. code:: cpp
+
+    enum class operation_attr_id {
+        priority    = /* unspecified */,
+        to_cache    = /* unspecified */,
+        synchronous = /* unspecified */,
+        match_id    = /* unspecified */
+
+        last_value  = /* unspecified, equal to the largest of all the values above */
+    };
+
+operation_attr_id::priority
+    the priority of the communication operation
+operation_attr_id::to_cache
+    | persistent/non-persistent communication operation
+    | should be used in conjunction with ``match_id``
+operation_attr_id::synchronous
+    synchronous/asynchronous communication operation
+operation_attr_id::match_id
+    | the unique identifier of the operation
+    | in conjunction with ``to_cache``, it enables the caching of the communication operation
+
+The communication operation specific attribute identifiers may extend the list of common identifiers.
+
+The list of attribute identifiers that may be used for :ref:`Allreduce`, :ref:`Reduce` and :ref:`ReduceScatter` collective operations:
+
+.. code:: cpp
+
+    enum class allreduce_attr_id {
+        reduction_fn = /* unspecified */
+    };
+
+    enum class reduce_attr_id {
+        reduction_fn = /* unspecified */
+    };
+
+    enum class reduce_scatter_attr_id {
+        reduction_fn = /* unspecified */
+    };
+
+allreduce_attr_id::reduction_fn / reduce_attr_id::reduction_fn / reduce_scatter_attr_id::reduction_fn
+    a function pointer for the custom reduction operation that follows the signature:
+
+.. code:: cpp
+
+        typedef void (*reduction_fn)
+        (
+            const void*,      /* in_buf    */
+            size_t,           /* in_count  */
+            void*,            /* inout_buf */
+            size_t*,          /* out_count */
+            datatype,         /* datatype  */
+            const fn_context* /* context   */
+        );
+
+        typedef struct {
+            const char* match_id;
+            const size_t offset;
+        } fn_context;
+
+Creating an operation attribute object, which may be used in a corresponding communication operation:
+
+.. code:: cpp
+
+    template <class OpAttrType>
+    OpAttrType ccl::create_operation_attr();
+
+return ``OpAttrType``
+    an object to hold attributes for a specific communication operation
+
+The operation attribute classes shall provide ``get`` and ``set`` methods for getting and setting of values with specific attribute identifiers.

--- a/doc/rst/source/spec/operation_progress.rst
+++ b/doc/rst/source/spec/operation_progress.rst
@@ -1,0 +1,42 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+===========================
+Operation Progress Tracking
+===========================
+
+oneCCL communication operation shall return an event object to be used for tracking the operation's progress.
+
+The ``event`` class shall provide the ability to wait for completion of an operation in a blocking manner, the ability to check the completion status in a non-blocking manner, and the ability to retrieve the underlying native object that is signaled when the operation completes.
+
+Event
+*****
+
+Waiting for the completion of an operation in a blocking manner:
+
+.. code:: cpp
+
+    void event::wait();
+
+
+Checking for the completion of an operation in a non-blocking manner:
+
+.. code:: cpp
+
+    bool event::test();
+
+return ``bool``
+    ``true`` if the operation has been completed
+    ``false`` if the operation has not been completed
+
+
+Retrieving a native object that is signaled when the operation completes:
+
+.. code:: cpp
+
+    native_event_type event::get_native();
+
+return ``native_event_type``
+    | a native object that is signaled when the operation completes
+    | shall throw an exception if an ``event`` object does not wrap the native object

--- a/doc/rst/source/spec/reductions.rst
+++ b/doc/rst/source/spec/reductions.rst
@@ -1,0 +1,37 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+==========
+Reductions
+==========
+
+oneCCL specification defines the following reduction operations for :ref:`Allreduce`, :ref:`Reduce` and :ref:`ReduceScatter` collective operations:
+
+.. code:: cpp
+
+    enum class reduction
+    {
+        sum    = /* unspecified */,
+        prod   = /* unspecified */,
+        min    = /* unspecified */,
+        max    = /* unspecified */,
+        avg    = /* unspecified */,  
+        custom = /* unspecified */
+    };
+
+reduction::sum
+    elementwise summation
+reduction::prod
+    elementwise multiplication
+reduction::min
+    elementwise min
+reduction::max
+    elementwise max
+reduction::avg
+    arithmethic average
+reduction::custom
+    | specify user-defined reduction operation
+    | the actual reduction function must be passed through ``reduction_fn`` operation attribute
+
+:doc:`operation_attributes`


### PR DESCRIPTION
UXL has moved to a dynamic specification, so each project publishes its own spec alongside its documentation. This brings the oneCCL specification into `doc/rst/source/spec` and adds a Specification section to the sidebar, as oneMath did in uxlfoundation/oneMath#727.

The pages are edited rather than copied verbatim, so they read as part of this manual — 16 pages became 9, navigation two levels instead of four. I dropped the spec's Introduction and Programming Model (they restate existing pages, and the pattern list omits allgather, alltoall and point-to-point), the "version 1.0" page, three toctree-only wrappers, and the Point-To-Point section, since `api/operations/point-to-point.rst` covers send/recv more fully and without the spec copy's `Recv` block that declares `event CCL_API send(...)`.

Links to the retired spec sites now resolve locally. `api/concepts.rst` and `api/operations.rst` were doubly broken — dead `spec.oneapi.com` targets, written with single backticks so nothing rendered as a link at all.

Existing docs change by 27 lines of links and config. The build goes from 48 warnings to 33, none in `spec/`.
